### PR TITLE
User API 연동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ android {
 dependencies {
     def nav_version = "2.3.2"
     def lifecycleVersion = '2.2.0'
+    def retrofitVersion = '2.9.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
@@ -72,15 +73,22 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
 
     //retrofit2
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
 
     //rxjava2
     implementation "io.reactivex.rxjava2:rxjava:2.2.21"
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+
+    //Glide
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
 
+    //retrofit2
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+
+    //rxjava2
+    implementation "io.reactivex.rxjava2:rxjava:2.2.21"
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Lettero">
+        android:theme="@style/Theme.Lettero"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity android:name="com.nexters.lettero.presentation.main.activity.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/nexters/lettero/data/datasource/remote/LetteroNetworkHelper.kt
+++ b/app/src/main/java/com/nexters/lettero/data/datasource/remote/LetteroNetworkHelper.kt
@@ -2,20 +2,29 @@ package com.nexters.lettero.data.datasource.remote
 
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
 
 object LetteroNetworkHelper {
-    private const val BASE_URL = "http://ec2-3-19-215-20.us-east-2.compute.amazonaws.com/"
+    private const val BASE_URL = "http://ec2-3-19-215-20.us-east-2.compute.amazonaws.com/api/"
     private var retrofitService: Retrofit? = null
 
     fun<T> getService(service: Class<T>):T {
         if(retrofitService == null) {
             val okHttpClient = OkHttpClient.Builder().addInterceptor { chain ->
                 val newRequest = chain.request().newBuilder()
-                    .addHeader("Authorization", "DUMMY_TOKEN1") //TODO : 추후 변경 예정
+                    .addHeader("Authorization", "Bearer DUMMY_TOKEN1") //TODO : 추후 변경 예정
                     .build()
 
                 chain.proceed(newRequest)
             }.build()
+
+            retrofitService = Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build()
         }
 
         return retrofitService!!.create(service)

--- a/app/src/main/java/com/nexters/lettero/data/datasource/remote/LetteroNetworkHelper.kt
+++ b/app/src/main/java/com/nexters/lettero/data/datasource/remote/LetteroNetworkHelper.kt
@@ -1,0 +1,23 @@
+package com.nexters.lettero.data.datasource.remote
+
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+object LetteroNetworkHelper {
+    private const val BASE_URL = "http://ec2-3-19-215-20.us-east-2.compute.amazonaws.com/"
+    private var retrofitService: Retrofit? = null
+
+    fun<T> getService(service: Class<T>):T {
+        if(retrofitService == null) {
+            val okHttpClient = OkHttpClient.Builder().addInterceptor { chain ->
+                val newRequest = chain.request().newBuilder()
+                    .addHeader("Authorization", "DUMMY_TOKEN1") //TODO : 추후 변경 예정
+                    .build()
+
+                chain.proceed(newRequest)
+            }.build()
+        }
+
+        return retrofitService!!.create(service)
+    }
+}

--- a/app/src/main/java/com/nexters/lettero/data/datasource/remote/UserService.kt
+++ b/app/src/main/java/com/nexters/lettero/data/datasource/remote/UserService.kt
@@ -1,0 +1,25 @@
+package com.nexters.lettero.data.datasource.remote
+
+import com.nexters.lettero.data.model.ThumbNailResponse
+import com.nexters.lettero.data.model.User
+import io.reactivex.Single
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface UserService {
+
+    @GET("user/me")
+    fun getUserInfo(): Single<User>
+
+    @FormUrlEncoded
+    @POST("user/phone-number")
+    fun savePhoneNumber(uid: String): Single<User>
+
+    @FormUrlEncoded
+    @POST("user/firebase-token")
+    fun saveFirebaseToken(token: String): Single<User>
+
+    @GET("user/thumbnails")
+    fun getThumbNails(): Single<List<ThumbNailResponse>>
+}

--- a/app/src/main/java/com/nexters/lettero/data/model/ThumbNailResponse.kt
+++ b/app/src/main/java/com/nexters/lettero/data/model/ThumbNailResponse.kt
@@ -1,0 +1,10 @@
+package com.nexters.lettero.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ThumbNailResponse(
+    @SerializedName("thumbnailName")
+    val thumbnailName:String,
+    @SerializedName("thumbnailUrl")
+    val thumbnailUrl:String
+)

--- a/app/src/main/java/com/nexters/lettero/data/model/User.kt
+++ b/app/src/main/java/com/nexters/lettero/data/model/User.kt
@@ -1,0 +1,16 @@
+package com.nexters.lettero.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class User(
+    @SerializedName("userId")
+    val userId: Long,
+    @SerializedName("nickName")
+    val nickName:String,
+    @SerializedName("thumbnail")
+    val thumbnail:String,
+    @SerializedName("requiredPhoneNumber")
+    val requiredPhoneNumber: Boolean,
+    @SerializedName("requiredFirebaseToken")
+    val requiredFirebaseToken: Boolean
+)

--- a/app/src/main/java/com/nexters/lettero/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/nexters/lettero/domain/repository/UserRepository.kt
@@ -1,0 +1,16 @@
+package com.nexters.lettero.domain.repository
+
+import com.nexters.lettero.data.model.ThumbNailResponse
+import com.nexters.lettero.data.model.User
+import io.reactivex.Single
+
+interface UserRepository {
+
+    fun getUserInfo(): Single<User>
+
+    fun savePhoneNumber(number: String): Single<User>
+
+    fun saveFirebaseToken(token: String): Single<User>
+
+    fun getThumbNails(): Single<List<ThumbNailResponse>>
+}

--- a/app/src/main/java/com/nexters/lettero/domain/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/nexters/lettero/domain/repository/UserRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.nexters.lettero.domain.repository
+
+import com.nexters.lettero.data.datasource.remote.LetteroNetworkHelper
+import com.nexters.lettero.data.datasource.remote.UserService
+import com.nexters.lettero.data.model.ThumbNailResponse
+import com.nexters.lettero.data.model.User
+import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+
+class UserRepositoryImpl() : UserRepository {
+    private val userService = LetteroNetworkHelper.getService(UserService::class.java)
+
+    override fun getUserInfo(): Single<User> = userService.getUserInfo()
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+
+    override fun savePhoneNumber(number: String): Single<User> = userService.savePhoneNumber(number)
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+
+    override fun saveFirebaseToken(token: String): Single<User> =
+        userService.saveFirebaseToken(token)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+
+    override fun getThumbNails(): Single<List<ThumbNailResponse>> =
+        userService.getThumbNails()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+
+}

--- a/app/src/main/java/com/nexters/lettero/presentation/mypage/viewmodel/MyPageViewModel.kt
+++ b/app/src/main/java/com/nexters/lettero/presentation/mypage/viewmodel/MyPageViewModel.kt
@@ -1,15 +1,37 @@
 package com.nexters.lettero.presentation.mypage.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.nexters.lettero.data.model.User
+import com.nexters.lettero.domain.repository.UserRepositoryImpl
 import com.nexters.lettero.presentation.base.ViewModel
 
 class MyPageViewModel : ViewModel {
+    val userRepository = UserRepositoryImpl()
 
-    var name: String
-    var phoneNumber: String
+    private val _name = MutableLiveData<String>()
+    val name: LiveData<String>  = _name
+
+    private val _phoneNumber = MutableLiveData<String>()
+    val phoneNumber:LiveData<String> = _phoneNumber
+
+    private val _thumbNailUrl = MutableLiveData<String>()
+    val thumbNailUrl:LiveData<String> = _thumbNailUrl
 
     init {
-        //TODO : 사용자 정보 연동 후 변경 예정
-        name = "aaa"
-        phoneNumber = "010-0000-0000"
+        userRepository.getUserInfo().subscribe({
+            user: User?, t2: Throwable? ->
+            user?.let {
+                _name.value = user.nickName
+                _phoneNumber.value = user.userId.toString()
+                _thumbNailUrl.value = user.thumbnail
+            }
+            t2?.let {
+                _name.value = ""
+                _phoneNumber.value = ""
+            }
+        })
     }
+
+
 }

--- a/app/src/main/java/com/nexters/lettero/util/BindingAdapterUtil.kt
+++ b/app/src/main/java/com/nexters/lettero/util/BindingAdapterUtil.kt
@@ -1,0 +1,18 @@
+package com.nexters.lettero.util
+
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.nexters.lettero.R
+
+@BindingAdapter("app:imgUrl")
+fun loadImage(imageView: ImageView, imageUrl: String?) {
+    imageUrl?.let {
+        Glide.with(imageView)
+            .load(imageUrl)
+            .error(R.drawable.mypage_profile)
+            .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)
+            .into(imageView)
+    }
+}

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -62,7 +62,8 @@
             android:layout_marginTop="10dp"
             android:layout_marginStart="10dp"
             app:layout_constraintTop_toTopOf="@id/guide_profile_back"
-            app:layout_constraintStart_toStartOf="@id/guide_profile_back"/>
+            app:layout_constraintStart_toStartOf="@id/guide_profile_back"
+            app:imgUrl="@{vm.thumbNailUrl}"/>
 
         <TextView
             android:id="@+id/guide_profile_txt"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">ec2-3-19-215-20.us-east-2.compute.amazonaws.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
# 개요
- Network Helper를 구현하였습니다. 
- User API를 연동하였습니다.

## 구현
### LetteroNetworkHelper 구현
- 생성할 네트워크 인터페이스를 제너릭으로 받아 서비스를 생성합니다.
- 인터셉터에 `Authorization` 헤더를 추가하였습니다.
- Retrofit 서비스 생성 시, `RxJava2CallAdapterFactory`를 추가하였습니다.
```kotlin
fun<T> getService(service: Class<T>):T {
      ... (생략) ...
        val newRequest = chain.request().newBuilder()
                    .addHeader("Authorization", "Bearer DUMMY_TOKEN1") //TODO : 추후 변경 예정
                    .build()
     ... (중략) ...
        return retrofitService!!.create(service)
    }
```
### UserRepository
- `getUserInfo` : 사용자 정보를 받아오는 API를 호출합니다.
- `savePhoneNumber` : 사용자의 전화번호를 저장합니다. 
- `saveFirebaseToken` : 사용자의 파이어베이스 토큰을 저장합니다.
- `getThumbNails` :  썸네일 전체 목록을 가져옵니다.

### MyPageFragment
- 사용자 정보를 받아오는 API를 연동하였습니다.
- 화면 첫 진입 시, API를 호출해 사용자 정보를 받아와 표시합니다.
- 이미지는 로드가 실패 시, `drawable/mypage_profile`을 기본으로 보여줍니다.
![Screenshot_2021-02-16-23-52-45-527_com nexters lettero](https://user-images.githubusercontent.com/9676685/108081546-6d977a00-70b4-11eb-8e73-6e26d0c868dc.jpg)

## 제안점
- 현재 마이페이지 상에서 API를 호출하였으나, 사용자 정보는 빈번하게 변하지 않을 것으로 예상이 됩니다.
- 사용자가 카카오톡 로그인 - 인증 후, API 호출이 아닌 안드로이드 메모리 상에 들고 있어야 생각이 됩니다. (어떻게 플로우를 짤 지 제안 주시면 좋을 것 같습니다.)
- 또한, `알림 수신` 기능을 위해 `SharedPreference` 작성을 진행하고자 합니다. (알림 수신 정보 선택을 기억하기 위함)